### PR TITLE
Add per-round match creation button

### DIFF
--- a/tournamentsWeb-dev/round.js
+++ b/tournamentsWeb-dev/round.js
@@ -1,6 +1,6 @@
 import { Match } from "./match.js";
 import { pushHistoryObject, discardHistory, latestHistoryChange } from "./history.js";
-import { matchesPositions, updateRoundList, closestNumber } from "./tournaments.js";
+import { matchesPositions, updateRoundList, closestNumber, addMatchToRound } from "./tournaments.js";
 import { global } from "./global.js";
 import * as CONSTANT from "./constants.js";
 
@@ -74,6 +74,7 @@ export class Round {
         this._biggestMatchOffset = 0;
         HTML.closest(".tournament_subdivision").querySelector(`.round_setting[data-round="${index+1}"] .round_delete_button`).addEventListener("click", function(){this.delete(true)}.bind(this));
         HTML.closest(".tournament_subdivision").querySelector(`.round_setting[data-round="${index+1}"] .round_settings_button`).addEventListener("click", function(){this.openSettingsWidget(true)}.bind(this));
+        HTML.closest(".tournament_subdivision").querySelector(`.round_setting[data-round="${index+1}"] .round_add_match_button`).addEventListener("click", () => addMatchToRound(this.getSectionName(), this.getIndex()));
         HTML.closest(".tournament_subdivision").querySelector(`.round_setting[data-round="${index+1}"] .legend_round_name`).addEventListener("change", function(event){
             this.getSettings().setSettings(event.target.value, undefined, undefined, true, this.getSection().name+"_"+this.getIndex());
         }.bind(this))

--- a/tournamentsWeb-dev/section.js
+++ b/tournamentsWeb-dev/section.js
@@ -160,6 +160,7 @@ export class Section {
                         </select>
                         <img class="round_action_button round_delete_button" src="https://cdn-icons-png.flaticon.com/512/484/484662.png" alt="Delete round">
                         <img class="round_action_button round_settings_button" src="https://cdn-icons-png.flaticon.com/512/2040/2040504.png" alt="Round settings">
+                        <img class="round_action_button round_add_match_button" src="https://cdn-icons-png.flaticon.com/512/992/992651.png" alt="Add match">
 
                     </div>
                 </div>

--- a/tournamentsWeb-dev/tournaments.css
+++ b/tournamentsWeb-dev/tournaments.css
@@ -415,6 +415,9 @@ span.connecting_dot_active {
     vertical-align: middle;
     cursor: pointer;
 }
+.round_add_match_button {
+    margin-left: 4px;
+}
 
 .round_grid_snap {
     width: 150px;

--- a/tournamentsWeb-dev/tournaments.html
+++ b/tournamentsWeb-dev/tournaments.html
@@ -66,6 +66,7 @@
                                     </select>
                                     <img class="round_action_button round_delete_button" src="https://cdn-icons-png.flaticon.com/512/484/484662.png" alt="Delete round">
                                     <img class="round_action_button round_settings_button" src="https://cdn-icons-png.flaticon.com/512/2040/2040504.png" alt="Round settings">
+                                    <img class="round_action_button round_add_match_button" src="https://cdn-icons-png.flaticon.com/512/992/992651.png" alt="Add match">
                                 </div>
                             </div>
                         </div>
@@ -82,6 +83,7 @@
                                     </select>
                                     <img class="round_action_button round_delete_button" src="https://cdn-icons-png.flaticon.com/512/484/484662.png" alt="Delete round">
                                     <img class="round_action_button round_settings_button" src="https://cdn-icons-png.flaticon.com/512/2040/2040504.png" alt="Round settings">
+                                    <img class="round_action_button round_add_match_button" src="https://cdn-icons-png.flaticon.com/512/992/992651.png" alt="Add match">
                                 </div>
                             </div>
                         </div>

--- a/tournamentsWeb-dev/tournaments.js
+++ b/tournamentsWeb-dev/tournaments.js
@@ -298,6 +298,17 @@ export function addMatches(){
     
 }
 
+export function addMatchToRound(sectionName, roundIndex){
+    latestHistoryChange.viewportHeight = matchesPositions.get(sectionName).get(roundIndex).element.closest("section.matches").offsetHeight;
+    const offset = matchesPositions.get(sectionName).get(roundIndex).createMatch();
+    adjustSectionCanvasHeight(sectionName, offset);
+    latestHistoryChange.type = "add_matches";
+    latestHistoryChange.section = sectionName;
+    latestHistoryChange.roundIndex = roundIndex;
+    latestHistoryChange.target = [[offset, matchesPositions.get(sectionName).get(roundIndex).getMatch(offset).matchId]];
+    pushHistoryObject();
+}
+
 export function adjustSectionCanvasHeight(sectionName, lastAddedMatchOffset, shrinkingAllowed = false){
     const section = document.querySelector(`.tournament_subdivision[data-sectionName='${sectionName}']`);
     console.log(section, sectionName);


### PR DESCRIPTION
## Summary
- add an `Add match` icon next to the round settings icon in HTML
- include the icon for new rounds inserted dynamically
- handle button clicks in `Round` to create one match via new `addMatchToRound`
- style the new `round_add_match_button` class

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687425512ec08333ad422e4bf643c65f