### PR TITLE
Allow inserting rounds between existing ones

### DIFF
--- a/tournamentsWeb-dev/round.js
+++ b/tournamentsWeb-dev/round.js
@@ -206,6 +206,7 @@ export class Round {
         }
         updateRoundList(sectionName);
         matchesPositions.get(sectionName).updateSnapping(roundIndex);
+        matchesPositions.get(sectionName).updateInsertButtons();
     }
 
     openSettingsWidget(){

--- a/tournamentsWeb-dev/section.js
+++ b/tournamentsWeb-dev/section.js
@@ -129,8 +129,8 @@ export class Section {
 
         let legendPosition = "afterend";
         let roundPosition = "afterend";
-        let legendPlacement = legendGrid.querySelector(`.rounds_settings > div:nth-of-type(${forceIndex})`);
-        let roundPlacement = matchesGrid.querySelector(`.viewport .matches > div:nth-of-type(${forceIndex})`);
+        let legendPlacement = legendGrid.querySelector(`div[data-round='${forceIndex}']`);
+        let roundPlacement = matchesGrid.querySelector(`.round_column[data-round='${forceIndex}']`);
         if(this.count() === 0){
             legendPosition = "beforeend";
             roundPosition = "beforebegin";
@@ -138,10 +138,16 @@ export class Section {
             roundPlacement = matchesGrid.querySelector(".add_round_column");
         }
         else if(forceIndex === 0){
-            legendPlacement = legendGrid.querySelector(`div:nth-of-type(1)`);
+            legendPlacement = legendGrid.querySelector(`div[data-round='1']`);
             legendPosition = "beforebegin";
             roundPosition = "beforebegin";
-            roundPlacement = matchesGrid.querySelector(`.viewport .matches > div:nth-of-type(1)`);
+            roundPlacement = matchesGrid.querySelector(`.round_column[data-round='1']`);
+        }
+        else if(forceIndex === this.count()){
+            legendPlacement = legendGrid.querySelector(`div[data-round='${forceIndex}']`);
+            legendPosition = "afterend";
+            roundPosition = "beforebegin";
+            roundPlacement = matchesGrid.querySelector(".add_round_column");
         }
         console.log(legendPlacement);
 

--- a/tournamentsWeb-dev/section.js
+++ b/tournamentsWeb-dev/section.js
@@ -32,6 +32,8 @@ export class Section {
         sectionElement.querySelector(".section_collapse_icon").addEventListener("click", section_collapse);
         sectionElement.querySelector(".section_delete_icon").addEventListener("click", section_delete);
 
+        this.updateInsertButtons();
+
     }
 
     setName(name, history = false){
@@ -186,6 +188,8 @@ export class Section {
             position++;
         }
 
+        this.updateInsertButtons();
+
         if(history){
             latestHistoryChange.type = "add_round";
             latestHistoryChange.section = this.name;
@@ -274,6 +278,29 @@ export class Section {
                 offset = round.biggestMatchOffset;
         }
         return offset;
+    }
+
+    updateInsertButtons(){
+        const matchesGrid = this.element.querySelector(".viewport .matches");
+        matchesGrid.querySelectorAll('.insert_round_column').forEach(e => e.remove());
+
+        const rounds = matchesGrid.querySelectorAll('.round_column');
+        rounds.forEach((round, index) => {
+            if(index < rounds.length - 1){
+                const col = document.createElement('div');
+                col.classList.add('insert_round_column');
+                const btn = document.createElement('div');
+                btn.classList.add('insert_round_button');
+                btn.textContent = '+';
+                btn.dataset.index = index + 1;
+                btn.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    this.createNewRound(e, true, parseInt(btn.dataset.index));
+                });
+                col.appendChild(btn);
+                round.insertAdjacentElement('afterend', col);
+            }
+        });
     }
 
 

--- a/tournamentsWeb-dev/tournaments.css
+++ b/tournamentsWeb-dev/tournaments.css
@@ -250,6 +250,29 @@ body.space .viewport{
     top: calc(50% - 156px);
 }
 
+.insert_round_column {
+    width: 60px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.insert_round_button {
+    width: 25px;
+    height: 25px;
+    background-color: #007bff;
+    display: none;
+    justify-content: center;
+    align-items: center;
+    border-radius: 50%;
+    border: 2px solid #e1e1e1;
+    cursor: pointer;
+}
+
+.insert_round_column:hover .insert_round_button {
+    display: flex;
+}
+
 span.right_connecting_dot {
     padding: 0;
     position: absolute;


### PR DESCRIPTION
## Summary
- add small `insert_round` buttons that appear on hover
- generate these buttons for every gap between rounds
- update buttons whenever rounds are added or deleted

## Testing
- `npm test` *(fails: ENOENT)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687430acc5408333b8b239f5c078d737