### PR TITLE
Move snap mode select to round widget

### DIFF
--- a/tournamentsWeb-dev/.idea/vcs.xml
+++ b/tournamentsWeb-dev/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
   </component>
 </project>

--- a/tournamentsWeb-dev/round.js
+++ b/tournamentsWeb-dev/round.js
@@ -43,8 +43,6 @@ class RoundSettings{
         document.querySelector(`.tournament_subdivision[data-sectionname="${sectionName}"] .tournament_legend .rounds_settings div:nth-of-type(${roundIndex+1}) .legend_round_name`).value = this.name;
         document.querySelector(`.tournament_subdivision[data-sectionname="${sectionName}"] .tournament_legend .rounds_settings div:nth-of-type(${roundIndex+1}) .legend_start`).textContent = this.startTime;
         document.querySelector(`.tournament_subdivision[data-sectionname="${sectionName}"] .tournament_legend .rounds_settings div:nth-of-type(${roundIndex+1}) .legend_format`).textContent = "BO" + this.format;
-        document.querySelector(`.tournament_subdivision[data-sectionname="${sectionName}"] .tournament_legend .rounds_settings .round_setting[data-round="${roundIndex+1}"] .round_grid_snap`).value = this.snappingMode;
-        console.log("IMPORTANT",document.querySelector(`.tournament_subdivision[data-sectionname="${sectionName}"] .tournament_legend .rounds_settings .round_setting[data-round="${roundIndex+1}"] .round_grid_snap`), document.querySelector(`.tournament_subdivision[data-sectionname="${sectionName}"] .tournament_legend .rounds_settings .round_setting[data-round="${roundIndex+1}"] .round_grid_snap`).value);
         if(format)
             RoundSettings.resetMatchesFormat(matchesPositions.get(sectionName).get(roundIndex));
         if(startTime)

--- a/tournamentsWeb-dev/section.js
+++ b/tournamentsWeb-dev/section.js
@@ -156,12 +156,6 @@ export class Section {
                     <input type="text" class="legend_round_name" value="Round ${newRoundNumber}">
                     <div><p class="legend_format">BO1</p>, <p class="legend_start">ASAP</p></div>
                     <div>
-                        <select class="round_grid_snap">
-                            <option value="Initial">Initial</option>
-                            <option value="Elimination">Elimination</option>
-                            <option value="Same as previous">Same as previous</option>
-                            <option value="Free" selected="selected">Free</option>
-                        </select>
                         <img class="round_action_button round_delete_button" src="https://cdn-icons-png.flaticon.com/512/484/484662.png" alt="Delete round">
                         <img class="round_action_button round_settings_button" src="https://cdn-icons-png.flaticon.com/512/2040/2040504.png" alt="Round settings">
                         <img class="round_action_button round_add_match_button" src="https://cdn-icons-png.flaticon.com/512/992/992651.png" alt="Add match">
@@ -169,7 +163,6 @@ export class Section {
                     </div>
                 </div>
             </div>`);
-        legendGrid.querySelector(`div[data-round='${newRoundNumber}'] .round_grid_snap`).addEventListener("change", snapModeChange);
         
         const roundElement = roundHTML(newRoundNumber);
         roundPlacement.insertAdjacentElement(roundPosition, roundElement);
@@ -426,7 +419,7 @@ export class Section {
 
     updateSnapping(startRoundIndex){
         for(let i = startRoundIndex; i< this.count(); i++){
-            const value = this.element.querySelector(`.rounds_settings div[data-round='${i+1}'] .round_grid_snap`).value;
+            const value = this.get(i).getSettings().snappingMode;
             console.log("roundIndex ", i, value);
             switch(value){
                 case "Free":
@@ -639,11 +632,8 @@ function roundHTML(roundNumber){
 
 
 
-export function snapModeChange(event){
-    const sectionName = event.target.closest(".tournament_subdivision").dataset.sectionname;
-    const roundIndex = event.target.closest(".round_setting").dataset.round -1;
+export function snapModeChange(sectionName, roundIndex){
     console.log(sectionName, roundIndex);
-    //musime projet vsechny nasledujici kola, muzeme totiz zmenit neco treba v pulce
+    // Update snapping for this round and subsequent rounds
     matchesPositions.get(sectionName).updateSnapping(roundIndex);
-    
 }

--- a/tournamentsWeb-dev/tournaments.css
+++ b/tournamentsWeb-dev/tournaments.css
@@ -1082,12 +1082,9 @@ GENERAL WIDGET
     gap: 1em;
 }
 .widget_content #round_edit_widget_disclaimer{
-    bottom: 0;
-    position: absolute;
     font-size: medium;
     text-align: center;
     left: 0;
-    padding: 1em;
 }
 .widget_content::-webkit-scrollbar{
     width: 4px;

--- a/tournamentsWeb-dev/tournaments.html
+++ b/tournamentsWeb-dev/tournaments.html
@@ -451,6 +451,7 @@
                     </h3>
                 </div>
                 <div class="widget_content">
+                    <p id="round_edit_widget_disclaimer">Changing these settings will affect all the matches in this round, including the already set up ones!</p>
                     <h3>Default format:</h3>
                     <div class="tile_selector">
                         <label class="container">BO1
@@ -484,7 +485,7 @@
                         <option value="Same as previous">Same as previous</option>
                         <option value="Free" selected="selected">Free</option>
                     </select>
-                    <p id="round_edit_widget_disclaimer">Changing these settings will affect all the matches in this round, including the already set up ones!</p>
+
                 </div>
             </div>
         </div>

--- a/tournamentsWeb-dev/tournaments.html
+++ b/tournamentsWeb-dev/tournaments.html
@@ -58,12 +58,6 @@
                                 <input type="text" class="legend_round_name" value="Round 1">
                                 <div><p class="legend_format">BO1</p>, <p class="legend_start">ASAP</p></div>
                                 <div>
-                                    <select class="round_grid_snap">
-                                        <option value="Initial" selected="selected">Initial</option>
-                                        <option value="Elimination">Elimination</option>
-                                        <option value="Same as previous">Same as previous</option>
-                                        <option value="Free">Free</option>
-                                    </select>
                                     <img class="round_action_button round_delete_button" src="https://cdn-icons-png.flaticon.com/512/484/484662.png" alt="Delete round">
                                     <img class="round_action_button round_settings_button" src="https://cdn-icons-png.flaticon.com/512/2040/2040504.png" alt="Round settings">
                                     <img class="round_action_button round_add_match_button" src="https://cdn-icons-png.flaticon.com/512/992/992651.png" alt="Add match">
@@ -75,12 +69,6 @@
                                 <input type="text" class="legend_round_name" value="Round 2">
                                 <div><p class="legend_format">BO1</p>, <p class="legend_start">ASAP</p></div>
                                 <div>
-                                    <select class="round_grid_snap">
-                                        <option value="Initial">Initial</option>
-                                        <option value="Elimination">Elimination</option>
-                                        <option value="Same as previous">Same as previous</option>
-                                        <option value="Free" selected="selected">Free</option>
-                                    </select>
                                     <img class="round_action_button round_delete_button" src="https://cdn-icons-png.flaticon.com/512/484/484662.png" alt="Delete round">
                                     <img class="round_action_button round_settings_button" src="https://cdn-icons-png.flaticon.com/512/2040/2040504.png" alt="Round settings">
                                     <img class="round_action_button round_add_match_button" src="https://cdn-icons-png.flaticon.com/512/992/992651.png" alt="Add match">
@@ -489,6 +477,13 @@
                             min="2018-06-07T00:00" max="2018-06-14T00:00"/>
                         </div>
                     </div>
+                    <h3>Snapping mode:</h3>
+                    <select class="round_grid_snap" id="round_edit_widget_snapping">
+                        <option value="Initial">Initial</option>
+                        <option value="Elimination">Elimination</option>
+                        <option value="Same as previous">Same as previous</option>
+                        <option value="Free" selected="selected">Free</option>
+                    </select>
                     <p id="round_edit_widget_disclaimer">Changing these settings will affect all the matches in this round, including the already set up ones!</p>
                 </div>
             </div>

--- a/tournamentsWeb-dev/tournaments.js
+++ b/tournamentsWeb-dev/tournaments.js
@@ -7,7 +7,7 @@ import { getMatchPosition, setMatchPosition } from "./match.js";
 import { historyStack, forwardStack, undo, pushHistoryObject, discardHistory, latestHistoryChange } from "./history.js";
 import { Match } from "./match.js";
 import { Round } from "./round.js";
-import { Section, snapModeChange } from "./section.js";
+import { Section } from "./section.js";
 
 
 export let matchesPositions = new Map();
@@ -149,15 +149,9 @@ function initializeMatchesPositions(){
         for(const [indexRound, round] of rounds.entries()){
             //tohle je do budoucna lepsi udelat JS only a nemazat se se stavajicim HTML, proste to tam placnout touhle funkci
             const roundName = document.querySelector(`.tournament_subdivision[data-sectionName="${sectionName}"] .tournament_legend .rounds_settings div:nth-child(${indexRound+1}) .legend_round_name`);
-            if(getColumnSnappingMode(sectionName, indexRound) !== "Free"){
-                matchesPositions.get(sectionName).set(indexRound,new Round(indexRound, round, 200 , roundName.value, getColumnSnappingMode(sectionName, indexRound)));
-            }
-            else{
-                matchesPositions.get(sectionName).set(indexRound,new Round(indexRound, round, 0 , roundName.value, getColumnSnappingMode(sectionName, indexRound)));
-            }
+            matchesPositions.get(sectionName).set(indexRound, new Round(indexRound, round, 0, roundName.value, "Free"));
             
             //roundName.addEventListener("change", roundNameChange);
-            document.querySelector(`.tournament_subdivision[data-sectionName="${sectionName}"] .tournament_legend .rounds_settings div:nth-child(${indexRound+1}) .round_grid_snap`).addEventListener("change", snapModeChange);             
 
             const matches = round.querySelectorAll(".match");
             let offset = 0;
@@ -177,7 +171,7 @@ function initializeMatchesPositions(){
 
 
 export function getColumnSnappingMode(sectionName, columnIndex){
-    return document.querySelector(`.tournament_subdivision[data-sectionName="${sectionName}"] .tournament_legend .rounds_settings div[data-round='${(columnIndex+1)}'] .round_grid_snap`).value;
+    return matchesPositions.get(sectionName).get(columnIndex).getSettings().snappingMode;
 }
 
 

--- a/tournamentsWeb-dev/widget.js
+++ b/tournamentsWeb-dev/widget.js
@@ -51,6 +51,7 @@ class RoundWidget extends Widget{
         this._round = undefined;
         this._previouslySelectedFormat = undefined;
         this._previouslySetTime = undefined;
+        this._previouslySelectedSnap = undefined;
         Widget.limitDateInput(this._widget.querySelector("#round_edit_widget_start_time"));
     }
 
@@ -69,7 +70,9 @@ class RoundWidget extends Widget{
         if(settings.startTime !== "ASAP"){
             selectedStartTimeInput = this._widget.querySelector(`input[name='round_start_type'][value="custom"]`);
         }
-        
+        const snappingSelect = this._widget.querySelector('#round_edit_widget_snapping');
+        snappingSelect.value = settings.snappingMode;
+
         [selectedFormatInput, oldFormatInput, selectedStartTimeInput, oldStartTimeInput].forEach((element) => element.parentElement.style.transition = 'none' );
         selectedFormatInput.checked = true;
         selectedStartTimeInput.checked = true;
@@ -83,6 +86,7 @@ class RoundWidget extends Widget{
         Also handled in this.updateSettings()*/
         this._previouslySelectedFormat = selectedFormatInput.value;
         this._previouslySetTime = selectedStartTimeInput.value;
+        this._previouslySelectedSnap = snappingSelect.value;
         if(this._previouslySetTime === "custom"){
             this._widget.querySelector("#round_edit_widget_start_time").value = settings.startTime;
             this._previouslySetTime = settings.startTime;
@@ -104,6 +108,7 @@ class RoundWidget extends Widget{
         console.log("updating round settings from widget");
         let round_format = this._widget.querySelector('input[name="round_format"]:checked').value;
         let start_format = this._widget.querySelector('input[name="round_start_type"]:checked').value;
+        let snap_mode = this._widget.querySelector('#round_edit_widget_snapping').value;
         const section_name = this._widget.querySelector("#round_edit_section_id").textContent;
         if(start_format === "custom")
             start_format = this._widget.querySelector("#round_edit_widget_start_time").value;
@@ -112,8 +117,12 @@ class RoundWidget extends Widget{
             start_format = undefined;
         if(round_format === this._previouslySelectedFormat)
             round_format = undefined;
-        if(start_format || round_format){
-            this._round.getSettings().setSettings(undefined, start_format, round_format, true, section_name + "_" + this._round.getIndex());
+        if(snap_mode === this._previouslySelectedSnap)
+            snap_mode = undefined;
+        if(start_format || round_format || snap_mode){
+            this._round.getSettings().setSettings(undefined, start_format, round_format, true, section_name + "_" + this._round.getIndex(), snap_mode);
+            if(snap_mode)
+                this._round.getSection().updateSnapping(this._round.getIndex());
             this._round.updateLegend();
         }
     }


### PR DESCRIPTION
## Summary
- move `round_grid_snap` dropdown from round list to round widget
- store previous snapping mode and handle updates in widget
- get snapping mode from round settings instead of DOM
- initialize rounds with default `Free` snapping

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875143c1bf08333b066171828be2d67