### PR TITLE
Add match counter to round settings

### DIFF
--- a/tournamentsWeb-dev/round.js
+++ b/tournamentsWeb-dev/round.js
@@ -70,24 +70,28 @@ export class Round {
         this.settings = new RoundSettings(name, snappingOffset, snappingMode);
         this._collisionLines = [];
         this._biggestMatchOffset = 0;
+        this.counterElement = HTML.closest(".tournament_subdivision").querySelector(`.round_setting[data-round="${index+1}"] .round_match_counter`);
         HTML.closest(".tournament_subdivision").querySelector(`.round_setting[data-round="${index+1}"] .round_delete_button`).addEventListener("click", function(){this.delete(true)}.bind(this));
         HTML.closest(".tournament_subdivision").querySelector(`.round_setting[data-round="${index+1}"] .round_settings_button`).addEventListener("click", function(){this.openSettingsWidget(true)}.bind(this));
         HTML.closest(".tournament_subdivision").querySelector(`.round_setting[data-round="${index+1}"] .round_add_match_button`).addEventListener("click", () => addMatchToRound(this.getSectionName(), this.getIndex()));
         HTML.closest(".tournament_subdivision").querySelector(`.round_setting[data-round="${index+1}"] .legend_round_name`).addEventListener("change", function(event){
             this.getSettings().setSettings(event.target.value, undefined, undefined, true, this.getSection().name+"_"+this.getIndex());
         }.bind(this))
+        this.updateMatchCounter();
     }
 
     addMatch(offset, match){
         this.matches.set(offset, match);
         if(offset > this._biggestMatchOffset)
             this._biggestMatchOffset = offset;
+        this.updateMatchCounter();
     }
     removeMatch(offset){
         this.matches.delete(offset);
         if(this.biggestMatchOffset == offset)
             this.updateBiggestOffset();
-        
+        this.updateMatchCounter();
+
     }
 
     updateBiggestOffset(){
@@ -126,6 +130,12 @@ export class Round {
         for(let match of this.matches.values()){
             console.log(match);
             match.recalculateConnectors();
+        }
+    }
+
+    updateMatchCounter(){
+        if(this.counterElement){
+            this.counterElement.textContent = this.matches.size;
         }
     }
 

--- a/tournamentsWeb-dev/section.js
+++ b/tournamentsWeb-dev/section.js
@@ -159,7 +159,7 @@ export class Section {
                         <img class="round_action_button round_delete_button" src="https://cdn-icons-png.flaticon.com/512/484/484662.png" alt="Delete round">
                         <img class="round_action_button round_settings_button" src="https://cdn-icons-png.flaticon.com/512/2040/2040504.png" alt="Round settings">
                         <img class="round_action_button round_add_match_button" src="https://cdn-icons-png.flaticon.com/512/992/992651.png" alt="Add match">
-
+                        <span class="round_match_counter">0</span>
                     </div>
                 </div>
             </div>`);

--- a/tournamentsWeb-dev/tournaments.css
+++ b/tournamentsWeb-dev/tournaments.css
@@ -442,6 +442,19 @@ span.connecting_dot_active {
     margin-left: 4px;
 }
 
+.round_match_counter {
+    margin-left: 4px;
+    padding: 2px 6px;
+    background-color: #1e1e1e;
+    border: 2px solid rgb(255 255 255 / 15%);
+    border-radius: 8px;
+    color: var(--darkModeTextColor);
+    font-weight: bold;
+    min-width: 24px;
+    text-align: center;
+    display: inline-block;
+}
+
 /* Styling the section and container */
 #tournament_toolbar {
     padding: 10px;

--- a/tournamentsWeb-dev/tournaments.html
+++ b/tournamentsWeb-dev/tournaments.html
@@ -61,6 +61,7 @@
                                     <img class="round_action_button round_delete_button" src="https://cdn-icons-png.flaticon.com/512/484/484662.png" alt="Delete round">
                                     <img class="round_action_button round_settings_button" src="https://cdn-icons-png.flaticon.com/512/2040/2040504.png" alt="Round settings">
                                     <img class="round_action_button round_add_match_button" src="https://cdn-icons-png.flaticon.com/512/992/992651.png" alt="Add match">
+                                    <span class="round_match_counter">3</span>
                                 </div>
                             </div>
                         </div>
@@ -72,6 +73,7 @@
                                     <img class="round_action_button round_delete_button" src="https://cdn-icons-png.flaticon.com/512/484/484662.png" alt="Delete round">
                                     <img class="round_action_button round_settings_button" src="https://cdn-icons-png.flaticon.com/512/2040/2040504.png" alt="Round settings">
                                     <img class="round_action_button round_add_match_button" src="https://cdn-icons-png.flaticon.com/512/992/992651.png" alt="Add match">
+                                    <span class="round_match_counter">2</span>
                                 </div>
                             </div>
                         </div>

--- a/tournamentsWeb-dev/tournaments.js
+++ b/tournamentsWeb-dev/tournaments.js
@@ -161,6 +161,7 @@ function initializeMatchesPositions(){
                 matches[i].style.top = offset + "px";
                 offset += 200;
             }
+            matchesPositions.get(sectionName).get(indexRound).updateMatchCounter();
         }
     }
 }


### PR DESCRIPTION
## Summary
- show how many matches each round has
- style match counter in tournaments.css
- update round templates to include counter
- keep counters updated via Round class

## Testing
- `npm test` *(fails: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6875652773208333ab42fa17e9e01f4c