### PR TITLE
Add confirmation modal for deleting rounds

### DIFF
--- a/tournamentsWeb-dev/round.js
+++ b/tournamentsWeb-dev/round.js
@@ -222,14 +222,18 @@ export class Round {
     }
 
     promptDelete(){
-        const modal = document.getElementById("delete_round_modal");
-        const confirmBtn = modal.querySelector("#delete_round_confirm");
-        const cancelBtn = modal.querySelector("#delete_round_cancel");
-        modal.classList.add("show");
+        const widget = document.getElementById("delete_round_widget");
+        const confirmBtn = widget.querySelector("#delete_round_confirm");
+        const cancelBtn = widget.querySelector("#delete_round_cancel");
+        const closeBtn = widget.querySelector("#delete_round_close");
+        const blocker = widget.querySelector(".widget_blocker");
+        widget.classList.add("showing");
         const cleanup = () => {
-            modal.classList.remove("show");
+            widget.classList.remove("showing");
             confirmBtn.removeEventListener("click", onConfirm);
             cancelBtn.removeEventListener("click", onCancel);
+            closeBtn.removeEventListener("click", onCancel);
+            blocker.removeEventListener("click", onCancel);
         };
         const onConfirm = () => {
             cleanup();
@@ -239,6 +243,8 @@ export class Round {
 
         confirmBtn.addEventListener("click", onConfirm);
         cancelBtn.addEventListener("click", onCancel);
+        closeBtn.addEventListener("click", onCancel);
+        blocker.addEventListener("click", onCancel);
     }
 
     updateLegend(){

--- a/tournamentsWeb-dev/round.js
+++ b/tournamentsWeb-dev/round.js
@@ -71,7 +71,7 @@ export class Round {
         this._collisionLines = [];
         this._biggestMatchOffset = 0;
         this.counterElement = HTML.closest(".tournament_subdivision").querySelector(`.round_setting[data-round="${index+1}"] .round_match_counter`);
-        HTML.closest(".tournament_subdivision").querySelector(`.round_setting[data-round="${index+1}"] .round_delete_button`).addEventListener("click", function(){this.delete(true)}.bind(this));
+        HTML.closest(".tournament_subdivision").querySelector(`.round_setting[data-round="${index+1}"] .round_delete_button`).addEventListener("click", () => this.promptDelete());
         HTML.closest(".tournament_subdivision").querySelector(`.round_setting[data-round="${index+1}"] .round_settings_button`).addEventListener("click", function(){this.openSettingsWidget(true)}.bind(this));
         HTML.closest(".tournament_subdivision").querySelector(`.round_setting[data-round="${index+1}"] .round_add_match_button`).addEventListener("click", () => addMatchToRound(this.getSectionName(), this.getIndex()));
         HTML.closest(".tournament_subdivision").querySelector(`.round_setting[data-round="${index+1}"] .legend_round_name`).addEventListener("change", function(event){
@@ -219,6 +219,26 @@ export class Round {
 
     openSettingsWidget(){
         global.roundWidget.open(this);
+    }
+
+    promptDelete(){
+        const modal = document.getElementById("delete_round_modal");
+        const confirmBtn = modal.querySelector("#delete_round_confirm");
+        const cancelBtn = modal.querySelector("#delete_round_cancel");
+        modal.classList.add("show");
+        const cleanup = () => {
+            modal.classList.remove("show");
+            confirmBtn.removeEventListener("click", onConfirm);
+            cancelBtn.removeEventListener("click", onCancel);
+        };
+        const onConfirm = () => {
+            cleanup();
+            this.delete(true);
+        };
+        const onCancel = () => cleanup();
+
+        confirmBtn.addEventListener("click", onConfirm);
+        cancelBtn.addEventListener("click", onCancel);
     }
 
     updateLegend(){

--- a/tournamentsWeb-dev/tournaments.css
+++ b/tournamentsWeb-dev/tournaments.css
@@ -1291,3 +1291,40 @@ GENERAL WIDGET
       opacity: 0;
     }
 }
+
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    display: none;
+    justify-content: center;
+    align-items: center;
+    z-index: 5;
+}
+
+.modal.show {
+    display: flex;
+}
+
+.modal_content {
+    background: #1e1e1e;
+    padding: 20px;
+    border-radius: 8px;
+    text-align: center;
+    color: #e1e1e1;
+}
+
+.modal_buttons {
+    margin-top: 10px;
+    display: flex;
+    gap: 10px;
+    justify-content: center;
+}
+
+.modal_buttons button {
+    padding: 5px 15px;
+    cursor: pointer;
+}

--- a/tournamentsWeb-dev/tournaments.css
+++ b/tournamentsWeb-dev/tournaments.css
@@ -1292,39 +1292,23 @@ GENERAL WIDGET
     }
 }
 
-.modal {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.5);
-    display: none;
-    justify-content: center;
-    align-items: center;
-    z-index: 5;
-}
-
-.modal.show {
-    display: flex;
-}
-
-.modal_content {
-    background: #1e1e1e;
-    padding: 20px;
-    border-radius: 8px;
-    text-align: center;
-    color: #e1e1e1;
-}
-
-.modal_buttons {
+.confirm_buttons {
     margin-top: 10px;
     display: flex;
     gap: 10px;
     justify-content: center;
 }
 
-.modal_buttons button {
+.confirm_buttons button {
+    background-color: #007bff;
+    color: #e0e0e0;
+    border: none;
+    border-radius: 4px;
     padding: 5px 15px;
     cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+.confirm_buttons button:hover {
+    background-color: #0056b3;
 }

--- a/tournamentsWeb-dev/tournaments.html
+++ b/tournamentsWeb-dev/tournaments.html
@@ -497,15 +497,24 @@
         </div>
     </section>
 
-    <div id="delete_round_modal" class="modal">
-        <div class="modal_content">
-            <p>Opravdu chcete odstranit kolo ?</p>
-            <div class="modal_buttons">
-                <button id="delete_round_confirm">Odstranit</button>
-                <button id="delete_round_cancel">Zrušit</button>
+    <section class="widget" id="delete_round_widget">
+        <div class="widget_blocker"></div>
+        <div class="widget_section">
+            <div class="widget_container">
+                <div class="widget_sticky_header">
+                    <img src="https://tropse.pro/files/img/tropse-close.png" class="widget_close" id="delete_round_close" />
+                    <h3 class="widget_heading">Potvrzení odstranění</h3>
+                </div>
+                <div class="widget_content">
+                    <p>Opravdu chcete odstranit kolo ?</p>
+                    <div class="confirm_buttons">
+                        <button id="delete_round_confirm">Odstranit</button>
+                        <button id="delete_round_cancel">Zrušit</button>
+                    </div>
+                </div>
             </div>
         </div>
-    </div>
+    </section>
 
     <script type="module" src="tournaments.js"></script>
     <script src="userTesting/userTestingPlugin.js"></script><!--disable if not user testing-->

--- a/tournamentsWeb-dev/tournaments.html
+++ b/tournamentsWeb-dev/tournaments.html
@@ -497,7 +497,15 @@
         </div>
     </section>
 
-
+    <div id="delete_round_modal" class="modal">
+        <div class="modal_content">
+            <p>Opravdu chcete odstranit kolo ?</p>
+            <div class="modal_buttons">
+                <button id="delete_round_confirm">Odstranit</button>
+                <button id="delete_round_cancel">Zrušit</button>
+            </div>
+        </div>
+    </div>
 
     <script type="module" src="tournaments.js"></script>
     <script src="userTesting/userTestingPlugin.js"></script><!--disable if not user testing-->


### PR DESCRIPTION
## Summary
- add a modal window to confirm round deletion
- style the new modal
- hook round delete button to show confirmation dialog

## Testing
- `node -c round.js`
- `node -c tournaments.js`
- `node -c userTesting/userTestingPlugin.js`


------
https://chatgpt.com/codex/tasks/task_e_687bc58e875c83338bb840f9771040b2